### PR TITLE
Formatter locale don't change despite switch language

### DIFF
--- a/Component.php
+++ b/Component.php
@@ -128,7 +128,9 @@ class Component extends \yii\base\Component
             }
         } else if (Yii::$app->request->cookies->has($this->cookieName)) {
             if ($this->_isValidLanguage(Yii::$app->request->cookies->getValue($this->cookieName))) {
-                Yii::$app->language = Yii::$app->request->cookies->getValue($this->cookieName);
+                $language = Yii::$app->request->cookies->getValue($this->cookieName);
+                Yii::$app->language = $language;
+                Yii::$app->formatter->locale = $language;
                 return;
             } else {
                 Yii::$app->response->cookies->remove($this->cookieName);


### PR DESCRIPTION
Hi,
When language is changed by the extension component, the formatter locale parametter remains in the default language application.

Then the methods called by the formatter as "asDate()" or "asCurrency" aren't trasnlated.
Greatings